### PR TITLE
added makefile to standardize setup 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-SHELL:=/bin/bash
 PROJECT=transformer-experiments
 VERSION=3.8.2
 VENV=${PROJECT}-${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VENV=${PROJECT}-${VERSION}
 VENV_DIR=$(shell pyenv root)/versions/${VENV}
 PYTHON=${VENV_DIR}/bin/python
 
-## Make sure you have `pyenv` and `pyenv-virtualenv` installed beforehand
+## Assumption: You have `pyenv` and `pyenv-virtualenv` installed beforehand
 ##
 ## https://github.com/pyenv/pyenv
 ## https://github.com/pyenv/pyenv-virtualenv
@@ -16,13 +16,13 @@ ccbold=$(shell tput bold)
 ccgreen=$(shell tput setaf 2)
 ccso=$(shell tput smso)
 
-clean: ## >> remove all environment and build files
+clean: ## >> remove all environment and build files.
 	@echo ""
 	@echo "$(ccso)--> Removing virtual environment $(ccend)"
 	pyenv virtualenv-delete --force ${VENV}
 	rm .python-version
 
-build: ##@main >> build a new virtual environment
+build: ##@main >> build a new virtual environment.
 	@echo ""
 	@echo "$(ccso)--> Build $(ccend)"
 	$(MAKE) install
@@ -40,7 +40,7 @@ install: venv requirements.txt ##@main >> update requirements.txt inside the vir
 	@echo "$(ccso)--> Updating packages $(ccend)"
 	$(PYTHON) -m pip install -r requirements.txt
 
-deactivate: ##@main >> deactivate current virtualenv.
+deactivate: ##@main >> deactivate current virtualenv and use local system python
 	pyenv local system
 
 # And add help text after each target name starting with '\#\#'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+SHELL:=/bin/bash
+PROJECT=transformer-experiments
+VERSION=3.8.2
+VENV=${PROJECT}-${VERSION}
+VENV_DIR=$(shell pyenv root)/versions/${VENV}
+PYTHON=${VENV_DIR}/bin/python
+
+## Make sure you have `pyenv` and `pyenv-virtualenv` installed beforehand
+##
+## https://github.com/pyenv/pyenv
+## https://github.com/pyenv/pyenv-virtualenv
+##
+
+# Colors for echos
+ccend=$(shell tput sgr0)
+ccbold=$(shell tput bold)
+ccgreen=$(shell tput setaf 2)
+ccso=$(shell tput smso)
+
+clean: ## >> remove all environment and build files
+	@echo ""
+	@echo "$(ccso)--> Removing virtual environment $(ccend)"
+	pyenv virtualenv-delete --force ${VENV}
+	rm .python-version
+
+build: ##@main >> build a new virtual environment
+	@echo ""
+	@echo "$(ccso)--> Build $(ccend)"
+	$(MAKE) install
+
+venv: $(VENV_DIR)
+
+$(VENV_DIR):
+	@echo "$(ccso)--> Install and setup pyenv and virtualenv $(ccend)"
+	pyenv install --skip-existing ${VERSION}
+	python3 -m pip install --upgrade pip
+	pyenv virtualenv ${VERSION} ${VENV}
+	echo ${VENV} > .python-version
+
+install: venv requirements.txt ##@main >> update requirements.txt inside the virtual environment
+	@echo "$(ccso)--> Updating packages $(ccend)"
+	$(PYTHON) -m pip install -r requirements.txt
+
+deactivate: ##@main >> deactivate current virtualenv.
+	pyenv local system
+
+# And add help text after each target name starting with '\#\#'
+# A category can be added with @category
+HELP_FUNC = \
+	%help; \
+	while(<>) { push @{$$help{$$2 // 'options'}}, [$$1, $$3] if /^([a-zA-Z\-\$\(]+)\s*:.*\#\#(?:@([a-zA-Z\-\)]+))?\s(.*)$$/ }; \
+	print "usage: make [target]\n\n"; \
+	for (sort keys %help) { \
+	print "${WHITE}$$_:${RESET}\n"; \
+	for (@{$$help{$$_}}) { \
+	$$sep = " " x (32 - length $$_->[0]); \
+	print "  ${YELLOW}$$_->[0]${RESET}$$sep${GREEN}$$_->[1]${RESET}\n"; \
+	}; \
+	print "\n"; }
+
+help: ##@other >> Show this help.
+	@perl -e '$(HELP_FUNC)' $(MAKEFILE_LIST)
+	@echo ""
+	@echo "Note: to activate the environment in your local shell type:"
+	@echo "   $$ pyenv activate $(VENV)"


### PR DESCRIPTION
A makefile to standardize all setup.

Pins the python version to [3.8.2](https://github.com/jovsa/transformer-experiments/pull/1/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R2) and the name of the [virtualenv](https://github.com/jovsa/transformer-experiments/pull/1/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R2)

To invoke a command just call  `make <command>`  
> ex. `make build` or `make help`


assumes you have `pyenv` and `pyenv-virtualenv` installed beforehand. Will remove this assumption at a later time.